### PR TITLE
Update to Kubernetes v1.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a fork of awesome [Kubernetes The Hard Way](https://github.com/kelseyhig
 5. Upgraded CNI plugins to v0.7.1
 6. Upgraded etcd to 3.3.9
 7. Added section on critools
+8. Upgraded kubernetes to v1.13.4
 
 # Kubernetes The Hard Way
 
@@ -26,7 +27,7 @@ The target audience for this tutorial is someone planning to support a productio
 
 Kubernetes The Hard Way guides you through bootstrapping a highly available Kubernetes cluster with end-to-end encryption between components and RBAC authentication.
 
-* [Kubernetes](https://github.com/kubernetes/kubernetes) 1.11.2
+* [Kubernetes](https://github.com/kubernetes/kubernetes) 1.13.4
 * [containerd Container Runtime](https://github.com/containerd/containerd) 1.2.0-beta.2
 * [gVisor](https://github.com/google/gvisor) 08879266fef3a67fac1a77f1ea133c3ac75759dd
 * [CNI Container Networking](https://github.com/containernetworking/cni) 0.7.1

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -75,7 +75,7 @@ The `kubectl` command line utility is used to interact with the Kubernetes API S
 ### OS X
 
 ```
-curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/darwin/amd64/kubectl
+curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/darwin/amd64/kubectl
 ```
 
 ```
@@ -89,7 +89,7 @@ sudo mv kubectl /usr/local/bin/
 ### Linux
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl
 ```
 
 ```
@@ -102,7 +102,7 @@ sudo mv kubectl /usr/local/bin/
 
 ### Verification
 
-Verify `kubectl` version 1.10.2 or higher is installed:
+Verify `kubectl` version 1.13.4 or higher is installed:
 
 ```
 kubectl version --client
@@ -111,7 +111,7 @@ kubectl version --client
 > output
 
 ```
-Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.2", GitCommit:"81753b10df112992bf51bbc2c2f85208aad78335", GitTreeState:"clean", BuildDate:"2018-04-27T09:22:21Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.4", GitCommit:"c27b913fddd1a6c480c229191a087698aa92f0b1", GitTreeState:"clean", BuildDate:"2019-03-01T23:34:27Z", GoVersion:"go1.12", Compiler:"gc", Platform:"darwin/amd64"}
 ```
 
 Next: [Provisioning Compute Resources](03-compute-resources.md)

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -42,10 +42,10 @@ Download the official Kubernetes release binaries:
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kube-apiserver" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kube-controller-manager" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kube-scheduler" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl"
+  "https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kube-apiserver" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kube-controller-manager" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kube-scheduler" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl"
 ```
 
 Install the Kubernetes binaries:
@@ -168,7 +168,7 @@ Create the `kube-scheduler.yaml` configuration file:
 
 ```
 cat <<EOF | sudo tee /etc/kubernetes/config/kube-scheduler.yaml
-apiVersion: componentconfig/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "/var/lib/kubernetes/kube-scheduler.kubeconfig"
@@ -307,12 +307,12 @@ curl -k --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}/version
 ```
 {
   "major": "1",
-  "minor": "11",
-  "gitVersion": "v1.11.2",
-  "gitCommit": "bb9ffb1654d4a729bb4cec18ff088eacc153c239",
+  "minor": "13",
+  "gitVersion": "v1.13.4",
+  "gitCommit": "c27b913fddd1a6c480c229191a087698aa92f0b1",
   "gitTreeState": "clean",
-  "buildDate": "2018-08-07T23:08:19Z",
-  "goVersion": "go1.10.3",
+  "buildDate": "2019-02-28T13:30:26Z",
+  "goVersion": "go1.11.5",
   "compiler": "gc",
   "platform": "linux/amd64"
 }

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -43,14 +43,14 @@ sudo apt-get -y install socat conntrack ipset
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  https://github.com/kubernetes-incubator/cri-tools/releases/download/v1.11.1/crictl-v1.11.1-linux-amd64.tar.gz \
+  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.13.0/crictl-v1.13.0-linux-amd64.tar.gz \
   https://storage.googleapis.com/kubernetes-the-hard-way/runsc \
   https://github.com/opencontainers/runc/releases/download/v1.0.0-rc5/runc.amd64 \
   https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-amd64-v0.7.1.tgz \
   https://github.com/containerd/containerd/releases/download/v1.2.0-beta.2/containerd-1.2.0-beta.2.linux-amd64.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubelet
+  https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubectl \
+  https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kube-proxy \
+  https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/linux/amd64/kubelet
 ```
 
 Create the installation directories:
@@ -71,7 +71,7 @@ Install the worker binaries:
 chmod +x kubectl kube-proxy kubelet runc.amd64 runsc
 sudo mv runc.amd64 runc
 sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
-sudo tar -xvf crictl-v1.11.1-linux-amd64.tar.gz -C /usr/local/bin/
+sudo tar -xvf crictl-v1.13.0-linux-amd64.tar.gz -C /usr/local/bin/
 sudo tar -xvf cni-plugins-amd64-v0.7.1.tgz -C /opt/cni/bin/
 sudo tar -xvf containerd-1.2.0-beta.2.linux-amd64.tar.gz -C /
 ```
@@ -303,10 +303,10 @@ kubectl get nodes --kubeconfig admin.kubeconfig
 > output
 
 ```
-NAME             STATUS    ROLES     AGE       VERSION
-ip-10-240-0-20   Ready     <none>    21s       v1.11.2
-ip-10-240-0-21   Ready     <none>    25s       v1.11.2
-ip-10-240-0-22   Ready     <none>    25s       v1.11.2
+NAME             STATUS   ROLES    AGE   VERSION
+ip-10-240-0-20   Ready    <none>   51s   v1.13.4
+ip-10-240-0-21   Ready    <none>   51s   v1.13.4
+ip-10-240-0-22   Ready    <none>   51s   v1.13.4
 ```
 
 Next: [Configuring kubectl for Remote Access](10-configuring-kubectl.md)

--- a/docs/10-configuring-kubectl.md
+++ b/docs/10-configuring-kubectl.md
@@ -59,10 +59,10 @@ kubectl get nodes
 > output
 
 ```
-NAME             STATUS    ROLES     AGE       VERSION
-ip-10-240-0-20   Ready     <none>    4m        v1.11.2
-ip-10-240-0-21   Ready     <none>    4m        v1.11.2
-ip-10-240-0-22   Ready     <none>    4m        v1.11.2
+NAME             STATUS   ROLES    AGE     VERSION
+ip-10-240-0-20   Ready    <none>   3m35s   v1.13.4
+ip-10-240-0-21   Ready    <none>   3m35s   v1.13.4
+ip-10-240-0-22   Ready    <none>   3m35s   v1.13.4
 ```
 
 Next: [Provisioning Pod Network Routes](11-pod-network-routes.md)


### PR DESCRIPTION
This upgrades to Kubernetes v1.13.4. 

The only thing that didn't work out of the box was the kube-scheduler config. The `apiVersion` there had to be changed to `kubescheduler.config.k8s.io/v1alpha1` and then it worked. That change is in this PR.

I ran through all the smoke tests, and they all worked.