### PR TITLE
adding exception for us-east-1 on page 13

### DIFF
--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -271,6 +271,15 @@ Get the node name where the `untrusted` pod is running:
 
 ```
 INSTANCE_NAME=$(kubectl get pod untrusted --output=jsonpath='{.spec.nodeName}')
+```
+If you deployed the cluster on US-EAST-1 use the command below:
+```
+INSTANCE_IP=$(aws ec2 describe-instances \
+    --filters "Name=network-interface.private-dns-name,Values=${INSTANCE_NAME}.ec2.internal" \
+    --output text --query 'Reservations[].Instances[].PublicIpAddress')
+```
+If you deployed the cluster on ANY OTHER region use this command:
+```
 INSTANCE_IP=$(aws ec2 describe-instances \
     --filters "Name=network-interface.private-dns-name,Values=${INSTANCE_NAME}.${AWS_REGION}.compute.internal" \
     --output text --query 'Reservations[].Instances[].PublicIpAddress')

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -195,7 +195,15 @@ Retrieve the external IP address of a worker instance:
 
 ```
 INSTANCE_NAME=$(kubectl get pod $POD_NAME --output=jsonpath='{.spec.nodeName}')
-
+```
+If you deployed the cluster on US-EAST-1 use the command below:
+```
+EXTERNAL_IP=$(aws ec2 describe-instances \
+    --filters "Name=network-interface.private-dns-name,Values=${INSTANCE_NAME}.ec2.internal" \
+    --output text --query 'Reservations[].Instances[].PublicIpAddress')
+```
+If you deployed the cluster on ANY OTHER region use this command:
+```
 EXTERNAL_IP=$(aws ec2 describe-instances \
     --filters "Name=network-interface.private-dns-name,Values=${INSTANCE_NAME}.${AWS_REGION}.compute.internal" \
     --output text --query 'Reservations[].Instances[].PublicIpAddress')


### PR DESCRIPTION
When deploying the cluster on us-east-1 the default domain for instances is hostname.ec2.internal. This is different in other regions and that is why I wanted to add this note for people in us-east-1