### PR TITLE
Update to Kubernetes 1.18.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This is a fork of awesome [Kubernetes The Hard Way](https://github.com/kelseyhightower/kubernetes-the-hard-way) by Kelsey Hightower and is geared towards using it on AWS. Also thanks to [@slawekzachcial](https://github.com/slawekzachcial) for his [work](https://github.com/slawekzachcial/kubernetes-the-hard-way-aws) that made this easier. I have made some changes along the way:
 
-1. Upgraded kubernetes to v1.17.2
-2. Upgraded cri-tools to v1.17.0
-3. Upgraded containerd to v1.3.2
-4. Upgraded CNI plugins to v0.8.5
-5. Upgraded etcd to 3.3.18
+1. Upgraded kubernetes to v1.18.6
+2. Upgraded cri-tools to v1.18.0
+3. Upgraded containerd to v1.3.6
+4. Upgraded CNI plugins to v0.8.6
+5. Upgraded etcd to 3.4.10
 
 # Kubernetes The Hard Way
 
@@ -24,11 +24,11 @@ The target audience for this tutorial is someone planning to support a productio
 
 Kubernetes The Hard Way guides you through bootstrapping a highly available Kubernetes cluster with end-to-end encryption between components and RBAC authentication.
 
-* [Kubernetes](https://github.com/kubernetes/kubernetes) 1.17.2
-* [containerd Container Runtime](https://github.com/containerd/containerd) 1.3.2
-* [gVisor](https://github.com/google/gvisor) 08879266fef3a67fac1a77f1ea133c3ac75759dd
-* [CNI Container Networking](https://github.com/containernetworking/cni) 0.8.5
-* [etcd](https://github.com/coreos/etcd) 3.3.18
+* [Kubernetes](https://github.com/kubernetes/kubernetes) 1.18.6
+* [containerd Container Runtime](https://github.com/containerd/containerd) 1.3.6
+* [gVisor](https://github.com/google/gvisor) 20200818.0
+* [CNI Container Networking](https://github.com/containernetworking/cni) 0.8.6
+* [etcd](https://github.com/coreos/etcd) 3.4.10
 
 ## Labs
 

--- a/deployments/core-dns.yaml
+++ b/deployments/core-dns.yaml
@@ -99,7 +99,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: coredns/coredns:1.6.3
+        image: coredns/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -12,8 +12,8 @@ Download and install `cfssl` and `cfssljson` from the [cfssl repository](https:/
 ### OS X
 
 ```
-curl -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
-curl -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
+curl -o cfssl https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/darwin/cfssl
+curl -o cfssljson https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/darwin/cfssljson
 ```
 
 ```
@@ -34,25 +34,25 @@ brew install cfssl
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 \
-  https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl \
+  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
 ```
 
 ```
-chmod +x cfssl_linux-amd64 cfssljson_linux-amd64
+chmod +x cfssl cfssljson
 ```
 
 ```
-sudo mv cfssl_linux-amd64 /usr/local/bin/cfssl
+sudo mv cfssl /usr/local/bin/
 ```
 
 ```
-sudo mv cfssljson_linux-amd64 /usr/local/bin/cfssljson
+sudo mv cfssljson /usr/local/bin/
 ```
 
 ### Verification
 
-Verify `cfssl` version 1.2.0 or higher is installed:
+Verify `cfssl` and `cfssljson` version 1.4.1 or higher is installed:
 
 ```
 cfssl version
@@ -61,9 +61,19 @@ cfssl version
 > output
 
 ```
-Version: 1.2.0
-Revision: dev
-Runtime: go1.6
+Version: 1.4.1
+Runtime: go1.12.12.
+```
+
+```
+cfssljson --version
+```
+
+> output
+
+```
+Version: 1.4.1
+Runtime: go1.12.12.
 ```
 
 > The cfssljson command line utility does not provide a way to print its version.
@@ -75,7 +85,7 @@ The `kubectl` command line utility is used to interact with the Kubernetes API S
 ### OS X
 
 ```
-curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/darwin/amd64/kubectl
+curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/darwin/amd64/kubectl
 ```
 
 ```
@@ -89,7 +99,7 @@ sudo mv kubectl /usr/local/bin/
 ### Linux
 
 ```
-wget https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl
 ```
 
 ```
@@ -102,7 +112,7 @@ sudo mv kubectl /usr/local/bin/
 
 ### Verification
 
-Verify `kubectl` version 1.17.2 or higher is installed:
+Verify `kubectl` version 1.18.6 or higher is installed:
 
 ```
 kubectl version --client
@@ -111,7 +121,7 @@ kubectl version --client
 > output
 
 ```
-Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.2", GitCommit:"59603c6e503c87169aea6106f57b9f242f64df89", GitTreeState:"clean", BuildDate:"2020-01-23T14:21:36Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"darwin/amd64"}
+Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.6", GitCommit:"dff82dc0de47299ab66c83c626e08b245ab19037", GitTreeState:"clean", BuildDate:"2020-07-15T16:58:53Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"darwin/amd64"}
 ```
 
 Next: [Provisioning Compute Resources](03-compute-resources.md)

--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -97,7 +97,7 @@ IMAGE_ID=$(aws ec2 describe-images --owners 099720109477 \
   --filters \
   'Name=root-device-type,Values=ebs' \
   'Name=architecture,Values=x86_64' \
-  'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*' \
+  'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*' \
   | jq -r '.Images|sort_by(.Name)[-1]|.ImageId')
 ```
 

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -30,20 +30,21 @@ Download the official etcd release binaries from the [coreos/etcd](https://githu
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.3.18/etcd-v3.3.18-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.4.10/etcd-v3.4.10-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 ```
-tar -xvf etcd-v3.3.18-linux-amd64.tar.gz
-sudo mv etcd-v3.3.18-linux-amd64/etcd* /usr/local/bin/
+tar -xvf etcd-v3.4.10-linux-amd64.tar.gz
+sudo mv etcd-v3.4.10-linux-amd64/etcd* /usr/local/bin/
 ```
 
 ### Configure the etcd Server
 
 ```
 sudo mkdir -p /etc/etcd /var/lib/etcd
+sudo chmod 700 /var/lib/etcd
 sudo cp ca.pem kubernetes-key.pem kubernetes.pem /etc/etcd/
 ```
 
@@ -121,9 +122,9 @@ sudo ETCDCTL_API=3 etcdctl member list \
 > output
 
 ```
-3a57933972cb5131, started, controller-2, https://10.0.1.12:2380, https://10.0.1.12:2379
-f98dc20bce6225a0, started, controller-0, https://10.0.1.10:2380, https://10.0.1.10:2379
-ffed16798470cab5, started, controller-1, https://10.0.1.11:2380, https://10.0.1.11:2379
+bbeedf10f5bbaa0c, started, controller-2, https://10.0.1.12:2380, https://10.0.1.12:2379, false
+f9b0e395cb8278dc, started, controller-0, https://10.0.1.10:2380, https://10.0.1.10:2379, false
+eecdfcb7e79fc5dd, started, controller-1, https://10.0.1.11:2380, https://10.0.1.11:2379, false
 ```
 
 Next: [Bootstrapping the Kubernetes Control Plane](08-bootstrapping-kubernetes-controllers.md)

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -36,10 +36,10 @@ Download the official Kubernetes release binaries:
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kube-apiserver" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kube-controller-manager" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kube-scheduler" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kubectl"
+  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-apiserver" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-controller-manager" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-scheduler" \
+  "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl"
 ```
 
 Install the Kubernetes binaries:
@@ -96,7 +96,7 @@ ExecStart=/usr/local/bin/kube-apiserver \\
   --kubelet-client-certificate=/var/lib/kubernetes/kubernetes.pem \\
   --kubelet-client-key=/var/lib/kubernetes/kubernetes-key.pem \\
   --kubelet-https=true \\
-  --runtime-config api/all=true \\
+  --runtime-config='api/all=true' \\
   --service-account-key-file=/var/lib/kubernetes/service-account.pem \\
   --service-cluster-ip-range=10.32.0.0/24 \\
   --service-node-port-range=30000-32767 \\
@@ -129,7 +129,7 @@ Documentation=https://github.com/kubernetes/kubernetes
 
 [Service]
 ExecStart=/usr/local/bin/kube-controller-manager \\
-  --address=0.0.0.0 \\
+  --bind-address=0.0.0.0 \\
   --cluster-cidr=10.200.0.0/16 \\
   --cluster-name=kubernetes \\
   --cluster-signing-cert-file=/var/lib/kubernetes/ca.pem \\
@@ -304,14 +304,14 @@ curl -k --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}/version
 > output
 
 ```
-{
+{ 
   "major": "1",
-  "minor": "17",
-  "gitVersion": "v1.17.2",
-  "gitCommit": "59603c6e503c87169aea6106f57b9f242f64df89",
+  "minor": "18",
+  "gitVersion": "v1.18.6",
+  "gitCommit": "dff82dc0de47299ab66c83c626e08b245ab19037",
   "gitTreeState": "clean",
-  "buildDate": "2020-01-18T23:22:30Z",
-  "goVersion": "go1.13.5",
+  "buildDate": "2020-07-15T16:51:04Z",
+  "goVersion": "go1.13.9",
   "compiler": "gc",
   "platform": "linux/amd64"
 }

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -37,14 +37,14 @@ sudo apt-get -y install socat conntrack ipset
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.17.0/crictl-v1.17.0-linux-amd64.tar.gz \
+  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-amd64.tar.gz \
   https://storage.googleapis.com/kubernetes-the-hard-way/runsc \
-  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc10/runc.amd64 \
-  https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz \
-  https://github.com/containerd/containerd/releases/download/v1.3.2/containerd-1.3.2.linux-amd64.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.17.2/bin/linux/amd64/kubelet
+  https://github.com/opencontainers/runc/releases/download/v1.0.0-rc91/runc.amd64 \
+  https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz \
+  https://github.com/containerd/containerd/releases/download/v1.3.6/containerd-1.3.6-linux-amd64.tar.gz \
+  https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl \
+  https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kube-proxy \
+  https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubelet
 ```
 
 Create the installation directories:
@@ -65,9 +65,9 @@ Install the worker binaries:
 chmod +x kubectl kube-proxy kubelet runc.amd64 runsc
 sudo mv runc.amd64 runc
 sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
-sudo tar -xvf crictl-v1.17.0-linux-amd64.tar.gz -C /usr/local/bin/
-sudo tar -xvf cni-plugins-linux-amd64-v0.8.5.tgz -C /opt/cni/bin/
-sudo tar -xvf containerd-1.3.2.linux-amd64.tar.gz -C /
+sudo tar -xvf crictl-v1.18.0-linux-amd64.tar.gz -C /usr/local/bin/
+sudo tar -xvf cni-plugins-linux-amd64-v0.8.6.tgz -C /opt/cni/bin/
+sudo tar -xvf containerd-1.3.6-linux-amd64.tar.gz -C /
 ```
 
 ### Configure CNI Networking
@@ -108,6 +108,7 @@ Create the `loopback` network configuration file:
 cat <<EOF | sudo tee /etc/cni/net.d/99-loopback.conf
 {
     "cniVersion": "0.3.1",
+    "name": "lo",
     "type": "loopback"
 }
 EOF
@@ -271,6 +272,16 @@ EOF
 
 ### Start the Worker Services
 
+## Fix Ubuntu broken '/bin/modprobe' link
+
+In the latest version of Ubuntu 20.04 LTS (Focal) at the time of testing had the /sbin/modprobe symlink pointing to a invalid entry.  The utilty `modprobe` is needed for loading kernel modules and used by containerd, which will fail to start unless corrected:
+
+```
+! [[ -r /sbin/modprobe ]] && sudo ln -s /usr/bin/kmod /bin/kmod
+```
+
+## Start services
+
 ```
 sudo systemctl daemon-reload
 sudo systemctl enable containerd kubelet kube-proxy
@@ -299,9 +310,9 @@ kubectl get nodes --kubeconfig admin.kubeconfig
 
 ```
 NAME             STATUS   ROLES    AGE   VERSION
-ip-10-0-1-20   Ready    <none>   51s   v1.17.2
-ip-10-0-1-21   Ready    <none>   51s   v1.17.2
-ip-10-0-1-22   Ready    <none>   51s   v1.17.2
+ip-10-0-1-20   Ready    <none>   51s   v1.18.6
+ip-10-0-1-21   Ready    <none>   51s   v1.18.6
+ip-10-0-1-22   Ready    <none>   51s   v1.18.6
 ```
 
 Next: [Configuring kubectl for Remote Access](10-configuring-kubectl.md)

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -67,7 +67,8 @@ sudo mv runc.amd64 runc
 sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
 sudo tar -xvf crictl-v1.18.0-linux-amd64.tar.gz -C /usr/local/bin/
 sudo tar -xvf cni-plugins-linux-amd64-v0.8.6.tgz -C /opt/cni/bin/
-sudo tar -xvf containerd-1.3.6-linux-amd64.tar.gz -C /
+sudo tar -xvf containerd-1.3.6-linux-amd64.tar.gz
+sudo mv bin/* /bin/
 ```
 
 ### Configure CNI Networking
@@ -271,16 +272,6 @@ EOF
 ```
 
 ### Start the Worker Services
-
-## Fix Ubuntu broken '/bin/modprobe' link
-
-In the latest version of Ubuntu 20.04 LTS (Focal) at the time of testing had the /sbin/modprobe symlink pointing to a invalid entry.  The utilty `modprobe` is needed for loading kernel modules and used by containerd, which will fail to start unless corrected:
-
-```
-! [[ -r /sbin/modprobe ]] && sudo ln -s /usr/bin/kmod /bin/kmod
-```
-
-## Start services
 
 ```
 sudo systemctl daemon-reload

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -7,7 +7,7 @@ In this lab you will deploy the [DNS add-on](https://kubernetes.io/docs/concepts
 Deploy the `kube-dns` cluster add-on:
 
 ```
-kubectl create -f https://raw.githubusercontent.com/prabhatsharma/kubernetes-the-hard-way-aws/master/deployments/core-dns.yaml
+kubectl apply -f https://raw.githubusercontent.com/prabhatsharma/kubernetes-the-hard-way-aws/master/deployments/core-dns.yaml
 ```
 
 > output

--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -39,18 +39,24 @@ sudo ETCDCTL_API=3 etcdctl get \
 00000010  73 2f 64 65 66 61 75 6c  74 2f 6b 75 62 65 72 6e  |s/default/kubern|
 00000020  65 74 65 73 2d 74 68 65  2d 68 61 72 64 2d 77 61  |etes-the-hard-wa|
 00000030  79 0a 6b 38 73 3a 65 6e  63 3a 61 65 73 63 62 63  |y.k8s:enc:aescbc|
-00000040  3a 76 31 3a 6b 65 79 31  3a 7b 8e 59 78 0f 59 09  |:v1:key1:{.Yx.Y.|
-00000050  e2 6a ce cd f4 b6 4e ec  bc 91 aa 87 06 29 39 8d  |.j....N......)9.|
-00000060  70 e8 5d c4 b1 66 69 49  60 8f c0 cc 55 d3 69 2b  |p.]..fiI`...U.i+|
-00000070  49 bb 0e 7b 90 10 b0 85  5b b1 e2 c6 33 b6 b7 31  |I..{....[...3..1|
-00000080  25 99 a1 60 8f 40 a9 e5  55 8c 0f 26 ae 76 dc 5b  |%..`.@..U..&.v.[|
-00000090  78 35 f5 3e c1 1e bc 21  bb 30 e2 0c e3 80 1e 33  |x5.>...!.0.....3|
-000000a0  90 79 46 6d 23 d8 f9 a2  d7 5d ed 4d 82 2e 9a 5e  |.yFm#....].M...^|
-000000b0  5d b6 3c 34 37 51 4b 83  de 99 1a ea 0f 2f 7c 9b  |].<47QK....../|.|
-000000c0  46 15 93 aa ba 72 ba b9  bd e1 a3 c0 45 90 b1 de  |F....r......E...|
-000000d0  c4 2e c8 d0 94 ec 25 69  7b af 08 34 93 12 3d 1c  |......%i{..4..=.|
-000000e0  fd 23 9b ba e8 d1 25 56  f4 0a                    |.#....%V..|
-000000ea
+00000040  3a 76 31 3a 6b 65 79 31  3a b7 1a c3 4f c9 b7 c3  |:v1:key1:...O...|
+00000050  65 3a a7 4a e0 68 7b b1  7f ab d2 a7 b1 c3 f5 fe  |e:.J.h{.........|
+00000060  fc 60 3a b2 aa cd fc c7  d7 1c 8d 75 b0 bd 6c 36  |.`:........u..l6|
+00000070  13 dc 0e 20 b9 c8 ed b6  2b ac 5c 17 10 ff 79 40  |... ....+.\...y@|
+00000080  19 4f 14 3a 81 59 03 d8  dc 4f 4d a2 b3 1b 1c 4c  |.O.:.Y...OM....L|
+00000090  dd 02 cf 32 1d b6 38 2c  6d 2e 40 4d 01 a0 ed 7b  |...2..8,m.@M...{|
+000000a0  53 ff 8e 97 0f 0d 49 13  f1 bf c1 aa 72 26 fb d6  |S.....I.....r&..|
+000000b0  99 7a c5 98 55 a8 c1 27  d1 5e ed 6a 39 24 16 d2  |.z..U..'.^.j9$..|
+000000c0  60 12 63 cb 3e bf b3 77  5a 55 59 e0 61 03 16 2d  |`.c.>..wZUY.a..-|
+000000d0  d6 13 22 7c 3e fe a1 56  77 a8 85 6e 28 4d 1d b4  |.."|>..Vw..n(M..|
+000000e0  19 55 30 66 cd 08 84 94  cb a6 4d 2b 95 92 61 9b  |.U0f......M+..a.|
+000000f0  3b ed 1f 2a af 55 c1 ad  db ed c8 80 03 28 c6 c4  |;..*.U.......(..|
+00000100  78 ba 25 24 5d f3 a1 34  1f 32 0b 25 bd 13 ec 0b  |x.%$]..4.2.%....|
+00000110  12 21 09 3e bd c8 ec 19  01 3c 21 a8 24 cc d3 19  |.!.>.....<!.$...|
+00000120  cc 43 4e 95 b4 c9 2b 98  78 ba f2 1e 83 2d c3 98  |.CN...+.x....-..|
+00000130  88 eb 85 af df 90 32 a2  a9 8a ec 54 5f 6f f6 01  |......2....T_o..|
+00000140  7c ba 3a e9 b4 b3 3b e3  20 0a                    ||.:...;. .|
+0000014a
 ```
 
 The etcd key should be prefixed with `k8s:enc:aescbc:v1:key1`, which indicates the `aescbc` provider was used to encrypt the data with the `key1` encryption key.
@@ -111,13 +117,13 @@ curl --head http://127.0.0.1:8080
 
 ```
 HTTP/1.1 200 OK
-Server: nginx/1.17.3
-Date: Sat, 14 Sep 2019 13:54:34 GMT
+Server: nginx/1.19.2
+Date: Wed, 26 Aug 2020 17:22:59 GMT
 Content-Type: text/html
 Content-Length: 612
-Last-Modified: Tue, 13 Aug 2019 08:50:00 GMT
+Last-Modified: Tue, 11 Aug 2020 14:50:35 GMT
 Connection: keep-alive
-ETag: "5d5279b8-264"
+ETag: "5f32b03b-264"
 Accept-Ranges: bytes
 ```
 
@@ -143,7 +149,7 @@ kubectl logs $POD_NAME
 > output
 
 ```
-127.0.0.1 - - [14/May/2018:13:59:21 +0000] "HEAD / HTTP/1.1" 200 0 "-" "curl/7.52.1" "-"
+127.0.0.1 - - [26/Aug/2020:17:22:59 +0000] "HEAD / HTTP/1.1" 200 0 "-" "curl/7.29.0" "-"
 ```
 
 ### Exec
@@ -159,7 +165,7 @@ kubectl exec -ti $POD_NAME -- nginx -v
 > output
 
 ```
-nginx version: nginx/1.17.3
+nginx version: nginx/1.19.2
 ```
 
 ## Services
@@ -223,13 +229,13 @@ curl -I http://${EXTERNAL_IP}:${NODE_PORT}
 
 ```
 HTTP/1.1 200 OK
-Server: nginx/1.17.3
-Date: Sat, 14 Sep 2019 13:54:34 GMT
+Server: nginx/1.19.2
+Date: Wed, 26 Aug 2020 17:28:36 GMT
 Content-Type: text/html
 Content-Length: 612
-Last-Modified: Tue, 13 Aug 2019 08:50:00 GMT
+Last-Modified: Tue, 11 Aug 2020 14:50:35 GMT
 Connection: keep-alive
-ETag: "5d5279b8-264"
+ETag: "5f32b03b-264"
 Accept-Ranges: bytes
 ```
 


### PR DESCRIPTION
This PR addresses #15 and makes the following version changes:

- Kubernetes 1.17.2 -> 1.18.6
- cri-tools 1.17.0 -> 1.18.0
- containerd 1.3.2 -> 1.3.6
- CNI plugins 0.8.5 -> 0.8.6
- etcd 3.3.18 -> 3.4.10
- coredns 1.6.3 -> 1.7.0
- cfssl/cfssljson 1.2 -> 1.4.1
- ubuntu 18.04 lts (bionic) -> 20.04 lts (focal)

The above represent [the same version changes](https://github.com/kelseyhightower/kubernetes-the-hard-way/commit/ca96371e4d2d2176e8b2c3f5b656b5d92973479e) in the "upstream" repo this repo is meant to be based on. 

Additionally, the following changes were also needed:
- kube-apiserver systemd unit file had one change relating to the `--runtime-config` parameter needing to be in quotes (per the same upstream change)
- kube-controller-manager `--address` parameter changed to `--bind-address`.  
- this version of etcd requires more strict permissions on `/var/lib/etcd` to run (otherwise it refuses to start).
- lastly, the [containerd extraction](https://github.com/prabhatsharma/kubernetes-the-hard-way-aws/blame/4f2a28097f1c23aa8a375346e544e23eb293231e/docs/09-bootstrapping-kubernetes-workers.md#L70) was clobbering the /bin symlink to /usr/bin which which was [causing strange puzzling issues](https://github.com/prabhatsharma/kubernetes-the-hard-way-aws/issues/8).. i've changed this to match along the lines of [what Kelsey does](https://github.com/kelseyhightower/kubernetes-the-hard-way/blame/ca96371e4d2d2176e8b2c3f5b656b5d92973479e/docs/09-bootstrapping-kubernetes-workers.md#L84) now