### PR TITLE
use StrictHostKeyChecking=no ssh option to auto-accept new host keys

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -370,7 +370,8 @@ for instance in worker-0 worker-1 worker-2; do
     --filters "Name=tag:Name,Values=${instance}" \
     --output text --query 'Reservations[].Instances[].PublicIpAddress')
 
-  scp -i kubernetes.id_rsa ca.pem ${instance}-key.pem ${instance}.pem ubuntu@${external_ip}:~/
+  scp -i kubernetes.id_rsa -o StrictHostKeyChecking=no \
+    ca.pem ${instance}-key.pem ${instance}.pem ubuntu@${external_ip}:~/
 done
 ```
 
@@ -382,7 +383,7 @@ for instance in controller-0 controller-1 controller-2; do
     --filters "Name=tag:Name,Values=${instance}" \
     --output text --query 'Reservations[].Instances[].PublicIpAddress')
 
-  scp -i kubernetes.id_rsa \
+  scp -i kubernetes.id_rsa -o StrictHostKeyChecking=no \
     ca.pem ca-key.pem kubernetes-key.pem kubernetes.pem \
     service-account-key.pem service-account.pem ubuntu@${external_ip}:~/
 done


### PR DESCRIPTION
Addresses issue #18 

This will automatically add the new hosts' keys to the `~/.ssh/known_hosts` file without interactive prompt.  This speeds up running the commands, at the slight risk of not prompting user if they trust this (new) host.  The window between having created the new hosts and someone setting up a MITM scenario is miniscule enough that I felt this was an acceptable risk with the benefit of being able to get through the commands quicker (not having to pause to type 'yes' for each of the 3 worker/3 master nodes).