### PR TITLE
provision Pod Network Routes in a fresh shell

### DIFF
--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -15,6 +15,8 @@ In production workloads this functionality will be provided by CNI plugins like 
 Print the internal IP address and Pod CIDR range for each worker instance and create route table entries:
 
 ```sh
+VPC_ID=$(aws ec2 describe-vpcs --filters 'Name=tag:Name,Values=kubernetes-the-hard-way' --output text --query 'Vpcs[0].VpcId')
+ROUTE_TABLE_ID=$(aws ec2 create-route-table --vpc-id ${VPC_ID} --output text --query 'RouteTable.RouteTableId')
 for instance in worker-0 worker-1 worker-2; do
   instance_id_ip="$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=${instance}" \

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -16,7 +16,7 @@ Print the internal IP address and Pod CIDR range for each worker instance and cr
 
 ```sh
 VPC_ID=$(aws ec2 describe-vpcs --filters 'Name=tag:Name,Values=kubernetes-the-hard-way' --output text --query 'Vpcs[0].VpcId')
-ROUTE_TABLE_ID=$(aws ec2 create-route-table --vpc-id ${VPC_ID} --output text --query 'RouteTable.RouteTableId')
+ROUTE_TABLE_ID=$(aws ec2 describe-route-tables --filters 'Name=tag:Name,Values=kubernetes' "Name=vpc-id,Values=$VPC_ID" --output text --query 'RouteTables[0].RouteTableId')
 for instance in worker-0 worker-1 worker-2; do
   instance_id_ip="$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=${instance}" \


### PR DESCRIPTION
Currently the "Provisioning Pod Network Routes" assumes you have the `ROUTE_TABLE_ID` set in your env.
Added fetching of the route table ID to allow running it in a fresh shell.