### PR TITLE
assumption of default output being json leads to jq errors

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -94,6 +94,7 @@ KUBERNETES_PUBLIC_ADDRESS=$(aws elbv2 describe-load-balancers \
 
 ```sh
 IMAGE_ID=$(aws ec2 describe-images --owners 099720109477 \
+  --output json \
   --filters \
   'Name=root-device-type,Values=ebs' \
   'Name=architecture,Values=x86_64' \


### PR DESCRIPTION
Assumption of default output of JSON leads to jq command errors as follows

`parse error: Invalid numeric literal at line 1, column 7`