### PR TITLE
chore: fix copy for verification cluster endpoint

### DIFF
--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -312,7 +312,7 @@ KUBERNETES_PUBLIC_ADDRESS=$(aws elbv2 describe-load-balancers \
 Make a HTTP request for the Kubernetes version info:
 
 ```
-curl --cacert ca.pem https://${KUBERNETES_PUBLIC_ADDRESS}/version
+curl --cacert ca.pem https://$KUBERNETES_PUBLIC_ADDRESS/version 
 ```
 
 > output


### PR DESCRIPTION
During copying the command on OS X I noticed that there were added a few symbols, the after pasting the output was:

```
curl --cacert ca.pem https://$\{KUBERNETES_PUBLIC_ADDRESS\}/version
```

Which will not work and I had manually remove `\`. 