### PR TITLE
Changed security group from 0.0.0.0/0 to local public IP

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -51,10 +51,10 @@ SECURITY_GROUP_ID=$(aws ec2 create-security-group \
 aws ec2 create-tags --resources ${SECURITY_GROUP_ID} --tags Key=Name,Value=kubernetes
 aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol all --cidr 10.0.0.0/16
 aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol all --cidr 10.200.0.0/16
-aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 6443 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 443 --cidr 0.0.0.0/0
-aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol icmp --port -1 --cidr 0.0.0.0/0
+aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr $(curl https://ifconfig.io)
+aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 6443 --cidr $(curl https://ifconfig.io)
+aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 443 --cidr $(curl https://ifconfig.io)
+aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol icmp --port -1 --cidr $(curl https://ifconfig.io)
 ```
 
 ### Kubernetes Public Access - Create a Network Load Balancer


### PR DESCRIPTION
Opening ports to 0.0.0.0/0 (that are not supposed to be access by anyone in the world) is a security vulnerability. If the person following the guide leaves the lab up for further testing, this could create security vulnerabilities they are unaware of. The change will swap out the 0.0.0.0/0 for the current public IP address. This will allow the student to do the lab without opening up their security groups to the world. 