### PR TITLE
Update 11-pod-network-routes.md

### DIFF
--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -15,6 +15,10 @@ In production workloads this functionality will be provided by CNI plugins like 
 Print the internal IP address and Pod CIDR range for each worker instance and create route table entries:
 
 ```sh
+ROUTE_TABLE_ID="$(aws ec2 describe-route-tables \
+  --filters 'Name=tag:Name,Values=kubernetes' \
+  --output text --query 'RouteTables[].RouteTableId')"
+
 for instance in worker-0 worker-1 worker-2; do
   instance_id_ip="$(aws ec2 describe-instances \
     --filters "Name=tag:Name,Values=${instance}" \


### PR DESCRIPTION
Add definition for missing var ROUTE_TABLE_ID if not using the same shell session as during creation in section 03.
Solves https://github.com/prabhatsharma/kubernetes-the-hard-way-aws/issues/5