### PR TITLE
Update 02-client-tools.md : modified cfssl and cfssljson installation steps for Linux.

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -39,7 +39,7 @@ Architecture:                       x86_64
 Model name:                         AMD EPYC 7763 64-Core Processor
 ```
 
-We could set the [version](https://github.com/cloudflare/cfssl/releases/tag/v1.6.5) and architecture as variable, download the tools and rename those.
+We could set the [version](https://github.com/cloudflare/cfssl/releases/tag/v1.6.5) and architecture as variables, download the tools and rename those.
 ```
 VERSION="1.6.5"
 ARCH="amd64"

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -49,7 +49,7 @@ wget -q --show-progress \
   https://github.com/cloudflare/cfssl/releases/download/v${VERSION}/cfssljson_${VERSION}_linux_${ARCH}
 
 mv cfssl_${VERSION}_linux_${ARCH} cfssl
-mv cfssljson_${VERSION}_linux_${ARCH}
+mv cfssljson_${VERSION}_linux_${ARCH} cfssljson
 ```
 
 Make those binaries executable.

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -32,16 +32,32 @@ brew install cfssl
 
 ### Linux
 
+Find the architecture using the following command (example output given).
 ```
-wget -q --show-progress --https-only --timestamping \
-  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl \
-  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
+$ lscpu | grep -i 'model name\|arch'
+Architecture:                       x86_64
+Model name:                         AMD EPYC 7763 64-Core Processor
 ```
 
+We could set the [version](https://github.com/cloudflare/cfssl/releases/tag/v1.6.5) and architecture as variable, download the tools and rename those.
+```
+VERSION="1.6.5"
+ARCH="amd64"
+
+wget -q --show-progress \ 
+  https://github.com/cloudflare/cfssl/releases/download/v${VERSION}/cfssl_${VERSION}_linux_${ARCH} \ 
+  https://github.com/cloudflare/cfssl/releases/download/v${VERSION}/cfssljson_${VERSION}_linux_${ARCH}
+
+mv cfssl_${VERSION}_linux_${ARCH} cfssl
+mv cfssljson_${VERSION}_linux_${ARCH}
+```
+
+Make those binaries executable.
 ```
 chmod +x cfssl cfssljson
 ```
 
+Move them to the `/usr/local/bin` so that they could be run from anywhere on the system. 
 ```
 sudo mv cfssl cfssljson /usr/local/bin/
 ```


### PR DESCRIPTION
The existing steps were failing.
```
$ wget --show-progress --https-only --timestamping   https://storage.googleapis.com/kubernetes-the-hard-way
/cfssl/1.4.1/linux/cfssl   https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
--2024-11-04 06:51:49--  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl
Resolving storage.googleapis.com (storage.googleapis.com)... 142.250.183.27, 142.250.183.155, 142.250.183.187, ...
Connecting to storage.googleapis.com (storage.googleapis.com)|142.250.183.27|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2024-11-04 06:51:49 ERROR 403: Forbidden.

--2024-11-04 06:51:49--  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
Reusing existing connection to storage.googleapis.com:443.
HTTP request sent, awaiting response... 403 Forbidden
2024-11-04 06:51:50 ERROR 403: Forbidden.
```

```
$ wget https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl   https://storage.goo
gleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
--2024-11-04 06:53:29--  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssl
Resolving storage.googleapis.com (storage.googleapis.com)... 142.250.183.155, 216.58.203.27, 216.58.203.59, ...
Connecting to storage.googleapis.com (storage.googleapis.com)|142.250.183.155|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2024-11-04 06:53:29 ERROR 403: Forbidden.

--2024-11-04 06:53:29--  https://storage.googleapis.com/kubernetes-the-hard-way/cfssl/1.4.1/linux/cfssljson
Reusing existing connection to storage.googleapis.com:443.
HTTP request sent, awaiting response... 403 Forbidden
2024-11-04 06:53:30 ERROR 403: Forbidden.```
